### PR TITLE
scikit-learn Updates

### DIFF
--- a/sdtm_mapper/requirements.txt
+++ b/sdtm_mapper/requirements.txt
@@ -5,7 +5,7 @@ botocore
 setuptools==39.1.0
 numpy
 Keras
-scikit_learn
+scikit-learn
 pathlib
 ################################################################
 # TensorFlow can be installed either as CPU or GPU versions.

--- a/sdtm_mapper/requirements.txt.bak
+++ b/sdtm_mapper/requirements.txt.bak
@@ -5,7 +5,7 @@ botocore
 setuptools==39.1.0
 numpy
 Keras
-scikit_learn
+scikit-learn
 pathlib
 ################################################################
 # TensorFlow can be installed either as CPU or GPU versions.

--- a/sdtm_mapper/setup.py
+++ b/sdtm_mapper/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     license='LICENSE',
     include_package_data=True,
-    install_requires=['numpy','pandas','pathlib','sas7bdat','boto3','botocore','sklearn','keras'],
+    install_requires=['numpy','pandas','pathlib','sas7bdat','boto3','botocore','scikit-learn','keras'],
     url='https://github.com/stomioka/sdtm_mapper',
     packages=setuptools.find_packages(exclude=('tests','doc','docs','images','poc','SDTMMapper','train_data','tutorials')),
     classifiers=[

--- a/sdtm_mapper/setup.py.bak
+++ b/sdtm_mapper/setup.py.bak
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     license='LICENSE',
     include_package_data=True,
-    install_requires=['numpy','pandas','pathlib','sas7bdat','boto3','botocore','sklearn','keras'],
+    install_requires=['numpy','pandas','pathlib','sas7bdat','boto3','botocore','scikit-learn','keras'],
     url='https://github.com/stomioka/sdtm_mapper',
     packages=setuptools.find_packages(exclude=('tests','doc','docs','images','poc','SDTMMapper','train_data','tutorials')),
     classifiers=[


### PR DESCRIPTION
The 'sklearn' PyPI package is deprecated, use 'scikit-learn' rather than 'sklearn' for pip commands.